### PR TITLE
fix frontend 500 error when probing service

### DIFF
--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -241,6 +241,9 @@ spec:
             httpGet:
               path: /apps
               port: http
+              httpHeaders:
+              - name: accept-language
+                value: en
             initialDelaySeconds: 30
             timeoutSeconds: 5
             periodSeconds: 30
@@ -250,7 +253,10 @@ spec:
             httpGet:
               path: /apps
               port: http
-            initialDelaySeconds: 1
+              httpHeaders:
+              - name: accept-language
+                value: en
+            initialDelaySeconds: 30
             timeoutSeconds: 5
             periodSeconds: 5
             successThreshold: 1


### PR DESCRIPTION
dify frontend needs a header `accept-language` to properly respond, bug: https://github.com/langgenius/dify/issues/3724

add more initial delay to prevent unnecessary check before frontend it ready