### PR TITLE
make livenessprobe and readnessprobe configurable

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -72,24 +72,14 @@ spec:
             - name: http
               containerPort: {{ .Values.api.containerPort }}
               protocol: TCP
+          {{- with .Values.api.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 2
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 10
-            timeoutSeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            failureThreshold: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
       {{- with .Values.volumes }}
@@ -237,30 +227,14 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.containerPort }}
               protocol: TCP
+          {{- with .Values.frontend.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /apps
-              port: http
-              httpHeaders:
-              - name: accept-language
-                value: en
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 2
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.frontend.readinessProbe}}
           readinessProbe:
-            httpGet:
-              path: /apps
-              port: http
-              httpHeaders:
-              - name: accept-language
-                value: en
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            failureThreshold: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
       {{- with .Values.frontend.nodeSelector }}
@@ -337,22 +311,14 @@ spec:
             - name: http
               containerPort: {{ .Values.sandbox.containerPort }}
               protocol: TCP
+          {{- with .Values.sandbox.livenessProbe }}
           livenessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 2
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sandbox.readinessProbe}}
           readinessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 1
-            timeoutSeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            failureThreshold: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.sandbox.resources | nindent 12 }}
       {{- with .Values.sandbox.nodeSelector }}

--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -156,6 +156,14 @@ spec:
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
+          {{- with .Values.worker.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
       {{- with .Values.volumes }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -113,6 +113,31 @@ frontend:
   tolerations: []
 
   affinity: {}
+  livenessProbe:
+    httpGet:
+      path: /apps
+      port: http
+      httpHeaders:
+      - name: accept-language
+        value: en
+    initialDelaySeconds: 3
+    timeoutSeconds: 5
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 2
+  readinessProbe:
+    httpGet:
+      path: /apps
+      port: http
+      httpHeaders:
+      - name: accept-language
+        value: en
+    initialDelaySeconds: 3
+    timeoutSeconds: 5
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 2
+
 
 api:
   replicaCount: 1
@@ -184,6 +209,25 @@ api:
 
   affinity: {}
 
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 2
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+    failureThreshold: 10
+
 worker:
   replicaCount: 1
 
@@ -233,6 +277,10 @@ worker:
   tolerations: []
 
   affinity: {}
+
+  # livenessprobe for worker, default no probe
+  livenessProbe: {}
+  readinessProbe: {}
 
 sandbox:
   replicaCount: 1
@@ -297,6 +345,24 @@ sandbox:
   tolerations: []
 
   affinity: {}
+
+
+  readinessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 1
+    timeoutSeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+    failureThreshold: 10
+  livenessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 2
 
 ##### dependencies #####
 


### PR DESCRIPTION
https://github.com/douban/charts/pull/79#discussion_r1577409989 as mentioned in the pr comment, the 30 seconds delay is overkill for frontend

But a configurable livenessprobe and readnessprobe could be useful, the user can change them for their need.


cc @majian159 
