### PR TITLE
Adapt to Dify 0.6.8

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,13 +20,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.3"
+appVersion: "0.6.8"
 
 dependencies:
   - name: redis

--- a/charts/dify/templates/configmap.yaml
+++ b/charts/dify/templates/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dify.fullname" . }}-sandbox-config
+data:
+  python-requirements.txt: |
+{{ .Values.sandbox.config.python_requirements | indent 4 }}

--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -315,6 +315,9 @@ spec:
             value: {{ .Values.sandbox.apiKey | quote }}
           {{- else }}
           {{- end }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /dependencies
           ports:
             - name: http
               containerPort: {{ .Values.sandbox.containerPort }}
@@ -341,3 +344,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "dify.fullname" . }}-sandbox-config

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -292,7 +292,12 @@ sandbox:
     repository: langgenius/dify-sandbox
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: ""
+    tag: "0.2.0"
+  config:
+    # python_requirements: |
+    #   numpy==1.20.3
+    #   scipy==1.6.3
+    python_requirements: ""
 
   envs:
   - name: GIN_MODE


### PR DESCRIPTION
1. Upgrade dify version to 0.6.8
2. Change default tag for sandbox to 0.2.0, latest does not point to the newest version
3. Use configmap to mount sandbox's python-requirements.txt
4. Update chart version to 0.3.5