### PR TITLE
update default values to have names

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -21,4 +21,4 @@ name: coredns
 sources:
 - https://github.com/coredns/coredns
 type: application
-version: 1.33.0
+version: 1.33.1

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -404,11 +404,15 @@ cilium:
       toPorts:
       - port: "53"
         protocol: "UDP"
+        name: "dns-udp"
       - port: "53"
         protocol: "TCP"
+        name: "dns-tcp"
     backend:
       toPorts:
       - port: "53"
         protocol: "UDP"
+        name: "dns-udp"
       - port: "53"
         protocol: "TCP"
+        name: "dns-tcp"


### PR DESCRIPTION
```
time="2024-09-19T09:35:17Z" level=warning msg="Failed to add CiliumLocalRedirectPolicy" ciliumLocalRedirectPolicyName=nodelocal-dns-coredns error="invalid address matcher port port 53 in the local redirect policy spec must have a valid IANA_SVC_NAME, as there are multiple ports" k8sApiVersion= k8sNamespace=kube-system k8sUID=3d205d8d-8bfb-4898-82fd-30efa01cd927 subsys=k8s-watcher
```