### PR TITLE
Updated ingress resources to adapt to K8S 1.17

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/ingress.yaml
+++ b/charts/dify/templates/ingress.yaml
@@ -36,7 +36,9 @@ spec:
       http:
         paths:
           - path: /console/api
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
               service:
@@ -48,7 +50,9 @@ spec:
               servicePort: {{ .Values.api.service.port }}
               {{- end }}
           - path: /api
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
               service:
@@ -60,7 +64,9 @@ spec:
               servicePort: {{ .Values.api.service.port }}
               {{- end }}
           - path: /v1
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
               service:
@@ -72,7 +78,9 @@ spec:
               servicePort: {{ .Values.api.service.port }}
               {{- end }}
           - path: /files
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
               service:
@@ -84,7 +92,9 @@ spec:
               servicePort: {{ .Values.api.service.port }}
               {{- end }}
           - path: /
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
               service:


### PR DESCRIPTION
Compatible with K8S 1.17.


The pathType field in the ingress resource is a feature introduced in K8s 1.18
Reference Links: https://opensource.googleblog.com/2020/09/kubernetes-ingress-goes-ga.html            