### PR TITLE
feat(dify): Add worker.envs and integrate into deployment

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -156,6 +156,9 @@ spec:
             {{- with .Values.global.extraBackendEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.worker.envs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -261,6 +261,8 @@ worker:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  # Add envs here for worker specific environment variables
+  envs: []
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Issue:
Currently in dify worker cannot set envs and only rely on global envs. This causes issue when we need to separate DB_DATABASE for worker.

### Pull request:
This pull request introduces support for worker-specific environment variables in the Helm chart for the `dify` project. The changes include updates to both the deployment template and the values file to allow configuration of these environment variables.

#### Support for Worker-Specific Environment Variables:

* [`charts/dify/templates/deployment.yaml`](diffhunk://#diff-1b490668d7ebf05a580faf61afcfe623db713f0f8fc1ea64912cc8d931c497a4R159-R161): Added a block to include worker-specific environment variables (`.Values.worker.envs`) in the deployment template.
* [`charts/dify/values.yaml`](diffhunk://#diff-e4fa46d01d6950486d2c3ec195f20e8567ac811cc2bd61f27683d24b4263da3dR264-R265): Introduced a new `envs` field under the `worker` section for defining worker-specific environment variables.