### PR TITLE
Fix dify redis password need escape characters

### DIFF
--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -102,7 +102,7 @@ commonBackendEnvs are for api and worker containers
 - name: REDIS_DB
   value: "1"
 - name: REDIS_PASSWORD
-  value: {{ .Values.redis.auth.password }}
+  value: {{ .Values.redis.auth.password | quote }}
 {{- end }}
 {{- if .Values.postgresql.embedded }}
 - name: DB_USERNAME


### PR DESCRIPTION
My password start with `#` and finally make plugin_daemon can't boot up.