### PR TITLE
Add resource policy annotation to PVC to fix plugin missing when restart pod

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.6.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "dify.fullname" . }}-plugin-daemon-pvc
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "dify.labels" . | nindent 4 }}
     app.kubernetes.io/component: plugin-daemon

--- a/charts/dify/templates/pvc.yaml
+++ b/charts/dify/templates/pvc.yaml
@@ -4,8 +4,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "dify.fullname" . }}-plugin-daemon-pvc
+  {{- if .Values.pluginDaemon.persistence.resourcePolicy }}
   annotations:
-    "helm.sh/resource-policy": keep
+    "helm.sh/resource-policy": {{ .Values.pluginDaemon.persistence.resourcePolicy | quote }}
+  {{- end }}
   labels:
     {{- include "dify.labels" . | nindent 4 }}
     app.kubernetes.io/component: plugin-daemon

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -423,6 +423,18 @@ pluginDaemon:
 
   containerPort: 5002
 
+  persistence:
+    enabled: true
+    # 使用默认的 storageClass，如果需要指定其他 storageClass，取消下面的注释并修改值
+    # storageClass: "rook-ceph-block"
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    # annotations: {}
+    # resourcePolicy defines the helm.sh/resource-policy for the PVC.
+    # Set to "keep" to retain the PVC when the Helm release is deleted or upgraded.
+    # Defaults to "" (no policy).
+    resourcePolicy: ""
+
   resources: {}
 
   nodeSelector: {}
@@ -431,12 +443,6 @@ pluginDaemon:
 
   affinity: {}
 
-  persistence:
-    enabled: true
-    # 使用默认的 storageClass，如果需要指定其他 storageClass，取消下面的注释并修改值
-    # storageClass: "rook-ceph-block"
-    accessMode: ReadWriteOnce
-    size: 20Gi
 ##### dependencies #####
 
 redis:


### PR DESCRIPTION
### Issue:
Plugin is stored in the plugin daemon volume, means that when the deployment is restarted, the plugin that has been downloaded from marketplace is missing, but the database is still have the record that the plugin is already installed

### Proposal:
This pull request includes updates to the Helm chart for the `dify` application, focusing on versioning and resource persistence. The most important changes is adding annotations to ensure the persistence of a specific resource and incrementing the chart version.

### Resource Persistence:
* [`charts/dify/templates/pvc.yaml`](diffhunk://#diff-a5b7b787f08afdcfbfde2ab2b8f18f30bbdb620d4c48e32950c2635fc92b43c2R7-R8): Added the `"helm.sh/resource-policy": keep` annotation to the PersistentVolumeClaim metadata to ensure the resource is retained during Helm uninstall operations.


### Versioning Updates:
* [`charts/dify/Chart.yaml`](diffhunk://#diff-259f492623271e68cd3b7d6f027f703072f2d8dcd2c62d17288ba76f5d717881L23-R23): Updated the chart version from `0.6.4` to `0.6.5` to reflect the changes in the application and its templates.