### PR TITLE
[Dify] Add /mcp prefix to ingress

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.6
+version: 0.6.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/ingress.yaml
+++ b/charts/dify/templates/ingress.yaml
@@ -91,6 +91,20 @@ spec:
               serviceName: {{ $fullName }}-api-svc
               servicePort: {{ .Values.api.service.port }}
               {{- end }}
+          - path: /mcp
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-api-svc
+                port:
+                  number: {{ .Values.api.service.port }}
+              {{- else }}
+              serviceName: {{ $fullName }}-api-svc
+              servicePort: {{ .Values.api.service.port }}
+              {{- end }}
           - path: /e/
             {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix


### PR DESCRIPTION
Based on the latest [Nginx template](https://github.com/langgenius/dify/blob/main/docker/nginx/conf.d/default.conf.template), the `/mcp` prefix should point to the API backend. This will allow workflows to be published as MCP and requests routed correctly.