### PR TITLE
fix(dify): Bump up chart version we depend on

### DIFF
--- a/charts/dify/Chart.lock
+++ b/charts/dify/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.1.5
+  version: 23.1.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.12
+  version: 18.0.8
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 14.1.8
-digest: sha256:39715ffe89119d01985861eced93747f441f12b6d27a28f6015c156c27bb56ec
-generated: "2025-10-08T20:33:43.975674+09:00"
+digest: sha256:a2655ea5c08c2b958ea1e63c8ebf427d66a1106fa219e523643939b6b9b2355d
+generated: "2025-10-09T18:48:15.170004+09:00"

--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.8
+version: 0.6.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,11 +30,11 @@ appVersion: "1.7.0"
 
 dependencies:
   - name: redis
-    version: ~19.1.1
+    version: ~23.1.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.embedded
   - name: postgresql
-    version: ~15.2.5
+    version: ~18.0.8
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.embedded
   - name: minio


### PR DESCRIPTION
### About
Simply updating the Chart repository did not resolve the ImagePullBackOff issue, so I will increase the version.

fix #139 