### PR TITLE
fix: add sandbox endpoint to worker so that it can be triggered by tr…

### DIFF
--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -159,6 +159,18 @@ spec:
             {{- with .Values.worker.envs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            - name: CODE_EXECUTION_ENDPOINT
+              value: "http://{{ include "dify.fullname" . }}-sandbox"
+            - name: CODE_EXECUTION_API_KEY
+            {{- if .Values.sandbox.apiKeySecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.sandbox.apiKeySecret }}
+                  key: sandbox-api-key
+            {{- else if .Values.sandbox.apiKey }}
+              value: {{ .Values.sandbox.apiKey | quote }}
+            {{- else }}
+            {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
after upgrade to dify 1.10.0 without RC tag,  the triggers not able to exec workflows automatcily due to workers not able to find the sandbox service