### PR TITLE
[Dify] Bump dify to 1.10.1-fix.1 to fix CVE-2025-66478 and bump dify plugin daemon to 0.5.1-local

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -26,7 +26,7 @@ version: 0.8.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.0"
+appVersion: "1.10.1-fix.1"
 
 dependencies:
   - name: redis

--- a/charts/dify/README.md
+++ b/charts/dify/README.md
@@ -17,7 +17,7 @@ global:
     # Set to the latest version of dify
     # Check the version here: https://github.com/langgenius/dify/releases
     # If not set, Using the default value in Chart.yaml
-    tag: "1.11.0"
+    tag: "1.10.1-fix.1"
   extraBackendEnvs:
   - name: SECRET_KEY
     value: "generate your own one"
@@ -54,7 +54,7 @@ To upgrade app, change the value of `global.image.tag` to the desired version
 ```yaml
 global:
   image:
-    tag: "1.11.0"
+    tag: "1.10.1-fix.1"
 ```
 
 Then upgrade the app with helm command

--- a/charts/dify/values.yaml
+++ b/charts/dify/values.yaml
@@ -20,7 +20,7 @@ global:
   # When set, environment variables like `CONSOLE_API_URL`, `CONSOLE_WEB_URL`, etc. will use this value instead of the generated value (see `dify.commonEnvs`)
   baseUrlOverride: ""
   image:
-    tag: "1.11.0"
+    tag: "1.10.1-fix.1"
   edition: "SELF_HOSTED"
   storageType: "s3"
   # the following extra configs would be injected into:


### PR DESCRIPTION
- Dify before 1.10.1-fix.1 are vulnerable to [CVE-2025-66478](https://nextjs.org/blog/CVE-2025-66478) due to using Next.js 15.x. (https://github.com/langgenius/dify/issues/29277)
- Dify Plugin Daemon 0.3.0-local seems to have compatibility issue starting from Dify 1.10.0. (https://github.com/langgenius/dify/issues/27713)
- Bump chart version to 0.8.1