### PR TITLE
rename reuse ingress setting

### DIFF
--- a/charts/aliyun-exporter/Chart.yaml
+++ b/charts/aliyun-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/aliyun-exporter/templates/httproute.yaml
+++ b/charts/aliyun-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/aliyun-exporter/values.yaml
+++ b/charts/aliyun-exporter/values.yaml
@@ -134,8 +134,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/archery/Chart.yaml
+++ b/charts/archery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 home: https://archerydms.com/
 description: Archery Helm chart for Kubernetes
 name: archery
-version: 0.4.2
+version: 0.4.3
 sources:
   - https://github.com/hhyo/Archery
 

--- a/charts/archery/templates/httproute.yaml
+++ b/charts/archery/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- $hostnames = append $hostnames . }}
   {{- end }}

--- a/charts/archery/values.yaml
+++ b/charts/archery/values.yaml
@@ -313,8 +313,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/channels/Chart.yaml
+++ b/charts/channels/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/channels/templates/httproute.yaml
+++ b/charts/channels/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/channels/values.yaml
+++ b/charts/channels/values.yaml
@@ -88,8 +88,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/codecov/Chart.yaml
+++ b/charts/codecov/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/codecov/templates/httproute.yaml
+++ b/charts/codecov/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/codecov/values.yaml
+++ b/charts/codecov/values.yaml
@@ -406,8 +406,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/healthchecks/Chart.yaml
+++ b/charts/healthchecks/Chart.yaml
@@ -1,4 +1,4 @@
-version: 1.0.9
+version: 1.0.10
 apiVersion: v2
 name: healthchecks
 description: A Helm chart for Kubernetes

--- a/charts/healthchecks/templates/httproute.yaml
+++ b/charts/healthchecks/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/healthchecks/values.yaml
+++ b/charts/healthchecks/values.yaml
@@ -152,8 +152,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/helpdesk/Chart.yaml
+++ b/charts/helpdesk/Chart.yaml
@@ -32,7 +32,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/helpdesk/templates/httproute.yaml
+++ b/charts/helpdesk/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/helpdesk/values.yaml
+++ b/charts/helpdesk/values.yaml
@@ -94,8 +94,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: v1.2.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png
 maintainers:

--- a/charts/kafka-ui/templates/httproute.yaml
+++ b/charts/kafka-ui/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -291,8 +291,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/karma/Chart.yaml
+++ b/charts/karma/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://github.com/wiremind/wiremind-helm-charts/tree/main/charts/karma
   - https://github.com/prymitive/karma
-version: 1.9.1
+version: 1.9.2
 appVersion: "0.85"
 maintainers:
   - name: desaintmartin

--- a/charts/karma/templates/httproute.yaml
+++ b/charts/karma/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/karma/values.yaml
+++ b/charts/karma/values.yaml
@@ -168,8 +168,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/mergeable/Chart.yaml
+++ b/charts/mergeable/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mergeable/templates/httproute.yaml
+++ b/charts/mergeable/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/mergeable/values.yaml
+++ b/charts/mergeable/values.yaml
@@ -102,8 +102,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nginx/templates/httproute.yaml
+++ b/charts/nginx/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -72,7 +72,7 @@ httpRoute:
     namespace: envoy-gateway-system
   # if set, the chart will create a httpRoute resource and route traffic to the service
   # the route would respect most of the settings in the ingress section, such as hostnames and annotations
-  ingressCompact: true
+  reuseIngressConfiguration: true
   # If you don't need ingress compact, you can define routing rules below
   hostnames: []
   extraPaths: []

--- a/charts/nonebot/Chart.yaml
+++ b/charts/nonebot/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nonebot/templates/httproute.yaml
+++ b/charts/nonebot/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/nonebot/values.yaml
+++ b/charts/nonebot/values.yaml
@@ -121,8 +121,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/overlord/Chart.yaml
+++ b/charts/overlord/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/overlord/templates/httproute.yaml
+++ b/charts/overlord/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/overlord/values.yaml
+++ b/charts/overlord/values.yaml
@@ -94,8 +94,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/pint/Chart.yaml
+++ b/charts/pint/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pint/templates/httproute.yaml
+++ b/charts/pint/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/pint/values.yaml
+++ b/charts/pint/values.yaml
@@ -146,8 +146,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/probot/Chart.yaml
+++ b/charts/probot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/probot/templates/httproute.yaml
+++ b/charts/probot/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/probot/values.yaml
+++ b/charts/probot/values.yaml
@@ -103,8 +103,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/prometheus-beanstalkd-exporter/Chart.yaml
+++ b/charts/prometheus-beanstalkd-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-beanstalkd-exporter/templates/httproute.yaml
+++ b/charts/prometheus-beanstalkd-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/prometheus-beanstalkd-exporter/values.yaml
+++ b/charts/prometheus-beanstalkd-exporter/values.yaml
@@ -124,8 +124,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/prometheus-memcached-exporter/Chart.yaml
+++ b/charts/prometheus-memcached-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prometheus-memcached-exporter/templates/httproute.yaml
+++ b/charts/prometheus-memcached-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/prometheus-memcached-exporter/values.yaml
+++ b/charts/prometheus-memcached-exporter/values.yaml
@@ -135,8 +135,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/qiniu-exporter/Chart.yaml
+++ b/charts/qiniu-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/qiniu-exporter/templates/httproute.yaml
+++ b/charts/qiniu-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/qiniu-exporter/values.yaml
+++ b/charts/qiniu-exporter/values.yaml
@@ -134,8 +134,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/selenium/Chart.yaml
+++ b/charts/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: selenium
-version: 1.3.1
+version: 1.3.2
 appVersion: 3.141.59
 description: Chart for selenium grid
 type: application

--- a/charts/selenium/templates/httproute.yaml
+++ b/charts/selenium/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/selenium/values.yaml
+++ b/charts/selenium/values.yaml
@@ -575,8 +575,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/tencentcloud-exporter/Chart.yaml
+++ b/charts/tencentcloud-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tencentcloud-exporter/templates/httproute.yaml
+++ b/charts/tencentcloud-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/tencentcloud-exporter/values.yaml
+++ b/charts/tencentcloud-exporter/values.yaml
@@ -156,8 +156,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/tencentcloud-info-exporter/Chart.yaml
+++ b/charts/tencentcloud-info-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tencentcloud-info-exporter/templates/httproute.yaml
+++ b/charts/tencentcloud-info-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/tencentcloud-info-exporter/values.yaml
+++ b/charts/tencentcloud-info-exporter/values.yaml
@@ -150,8 +150,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/tinyproxy-exporter/Chart.yaml
+++ b/charts/tinyproxy-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tinyproxy-exporter/templates/httproute.yaml
+++ b/charts/tinyproxy-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/tinyproxy-exporter/values.yaml
+++ b/charts/tinyproxy-exporter/values.yaml
@@ -124,8 +124,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/ucloud-exporter/Chart.yaml
+++ b/charts/ucloud-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ucloud-exporter/templates/httproute.yaml
+++ b/charts/ucloud-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/ucloud-exporter/values.yaml
+++ b/charts/ucloud-exporter/values.yaml
@@ -134,8 +134,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/charts/upyun-exporter/Chart.yaml
+++ b/charts/upyun-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/upyun-exporter/templates/httproute.yaml
+++ b/charts/upyun-exporter/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $root := . }}
 {{- $hostnames := (list) }}
-{{- if .Values.httpRoute.ingressCompact }}
+{{- if .Values.httpRoute.reuseIngressConfiguration }}
   {{- range .Values.ingress.hosts }}
     {{- if .host }}
       {{- $hostnames = append $hostnames .host }}

--- a/charts/upyun-exporter/values.yaml
+++ b/charts/upyun-exporter/values.yaml
@@ -134,8 +134,8 @@ httpRoute:
     name: envoy-gateway-bundle
     namespace: envoy-gateway-system
   # Reuse ingress host information if true; set to false to manage hostnames below
-  ingressCompact: true
-  # Explicit host overrides when ingressCompact is disabled
+  reuseIngressConfiguration: true
+  # Explicit host overrides when reuseIngressConfiguration is disabled
   hostnames: []
   # Extra HTTPRoute rules that will be appended before the default backend
   extraPaths: []

--- a/scripts/bump_changed_charts.py
+++ b/scripts/bump_changed_charts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Bump Helm chart versions for charts with local changes."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+CHARTS_DIR = REPO_ROOT / "charts"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from bump_chart_versions import bump_chart_version  # noqa: E402
+
+
+def run_git_status() -> list[str]:
+    rel_charts = CHARTS_DIR.relative_to(REPO_ROOT)
+    cmd = [
+        "git",
+        "-C",
+        str(REPO_ROOT),
+        "status",
+        "--porcelain",
+        "--untracked-files=normal",
+        str(rel_charts),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        print(proc.stderr.strip() or "Failed to run git status", file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    return proc.stdout.splitlines()
+
+
+def extract_chart_dirs(lines: Iterable[str]) -> list[Path]:
+    rel_charts = CHARTS_DIR.relative_to(REPO_ROOT)
+    rel_parts = rel_charts.parts
+    chart_dirs: set[Path] = set()
+    for raw in lines:
+        if len(raw) < 4:
+            continue
+        path_spec = raw[3:]
+        if " -> " in path_spec:
+            path_spec = path_spec.split(" -> ", 1)[1]
+        rel_path = Path(path_spec.rstrip("/"))
+        if len(rel_path.parts) <= len(rel_parts):
+            continue
+        if tuple(rel_path.parts[: len(rel_parts)]) != rel_parts:
+            continue
+        target = CHARTS_DIR.joinpath(*rel_path.parts[len(rel_parts) : len(rel_parts) + 1])
+        if target.is_dir():
+            chart_dirs.add(target)
+    return sorted(chart_dirs)
+
+
+def main() -> int:
+    if not CHARTS_DIR.is_dir():
+        print(f"Charts directory {CHARTS_DIR} not found", file=sys.stderr)
+        return 1
+
+    status_lines = run_git_status()
+    targets = extract_chart_dirs(status_lines)
+    if not targets:
+        print("No modified charts detected.")
+        return 0
+
+    bumped = 0
+    for chart_dir in targets:
+        chart_name = chart_dir.name
+        try:
+            old, new = bump_chart_version(chart_dir)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ERROR] {chart_name}: {exc}", file=sys.stderr)
+            continue
+        print(f"[OK] {chart_name}: {old} -> {new}")
+        bumped += 1
+
+    if bumped == 0:
+        print("No chart versions updated", file=sys.stderr)
+        return 1
+    print(f"Updated {bumped} chart versions.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`ingressCompact` 实际上应该写成 `ingressCompat`, 既然改名直接改成一个更明显的算了, 叫 `reuseIngressConfiguration`