### PR TITLE
fix(dify): de-duplicate container env vars (fixes declarative apply /…

### DIFF
--- a/charts/dify/Chart.yaml
+++ b/charts/dify/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dify/templates/_helpers.tpl
+++ b/charts/dify/templates/_helpers.tpl
@@ -207,3 +207,46 @@ commonBackendEnvs are for api and worker containers
 
 {{- end }}
 {{- end }}
+
+{{/*
+Container env assembly.
+
+A container's `env` is a strategic-merge list keyed by `name`. Emitting the same
+name twice (e.g. a var already in api.envs also set via global.extraBackendEnvs)
+is tolerated by the container runtime — last value wins — but breaks the
+strategic-merge diff used by `kubectl apply`, `helm upgrade`, and ArgoCD. The
+helpers below assemble each container's env in the existing upstream order and
+then de-duplicate, keeping the last occurrence of each name (same last-wins rule
+the runtime already applied) so the effective environment is unchanged while the
+rendered list stays well-formed.
+*/}}
+{{- define "dify.dedupeEnv" -}}
+{{- $items := .items -}}
+{{- $last := dict -}}
+{{- range $items -}}{{- $_ := set $last .name . -}}{{- end -}}
+{{- $order := list -}}
+{{- range $items -}}{{- if not (has .name $order) -}}{{- $order = append $order .name -}}{{- end -}}{{- end -}}
+{{- $out := list -}}
+{{- range $order -}}{{- $out = append $out (index $last .) -}}{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{- define "dify.backendEnvs" -}}
+{{- $ctx := .ctx -}}
+{{- $items := concat
+    (include "dify.commonEnvs" $ctx | fromYamlArray)
+    (include "dify.commonBackendEnvs" $ctx | fromYamlArray)
+    ($ctx.Values.global.extraEnvs | default list)
+    ($ctx.Values.global.extraBackendEnvs | default list)
+    (.componentEnvs | default list) -}}
+{{- include "dify.dedupeEnv" (dict "items" $items) -}}
+{{- end }}
+
+{{- define "dify.frontendEnvs" -}}
+{{- $ctx := .ctx -}}
+{{- $items := concat
+    (include "dify.commonEnvs" $ctx | fromYamlArray)
+    ($ctx.Values.global.extraEnvs | default list)
+    (.componentEnvs | default list) -}}
+{{- include "dify.dedupeEnv" (dict "items" $items) -}}
+{{- end }}

--- a/charts/dify/templates/deployment.yaml
+++ b/charts/dify/templates/deployment.yaml
@@ -43,17 +43,7 @@ spec:
           env:
             - name: MODE
               value: "api"
-            {{- include "dify.commonEnvs" . | nindent 12 }}
-            {{- include "dify.commonBackendEnvs" . | nindent 12 }}
-            {{- with .Values.global.extraEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.global.extraBackendEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.api.envs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "dify.backendEnvs" (dict "ctx" . "componentEnvs" .Values.api.envs) | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 12 }}
@@ -136,17 +126,7 @@ spec:
           env:
             - name: MODE
               value: "worker"
-            {{- include "dify.commonEnvs" . | nindent 12 }}
-            {{- include "dify.commonBackendEnvs" . | nindent 12 }}
-            {{- with .Values.global.extraEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.global.extraBackendEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.worker.envs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "dify.backendEnvs" (dict "ctx" . "componentEnvs" .Values.worker.envs) | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 12 }}
@@ -224,17 +204,7 @@ spec:
           env:
             - name: MODE
               value: "beat"
-            {{- include "dify.commonEnvs" . | nindent 12 }}
-            {{- include "dify.commonBackendEnvs" . | nindent 12 }}
-            {{- with .Values.global.extraEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.global.extraBackendEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.workerBeat.envs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "dify.backendEnvs" (dict "ctx" . "componentEnvs" .Values.workerBeat.envs) | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 12 }}
@@ -309,13 +279,7 @@ spec:
           image: "{{ .Values.frontend.image.repository }}:{{ coalesce .Values.frontend.image.tag .Values.global.image.tag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           env:
-          {{- include "dify.commonEnvs" . | nindent 12 }}
-          {{- with .Values.global.extraEnvs }}
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.frontend.envs }}
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "dify.frontendEnvs" (dict "ctx" . "componentEnvs" .Values.frontend.envs) | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.frontend.containerPort }}
@@ -510,17 +474,7 @@ spec:
               value: {{ .Values.pluginDaemon.difyInnerApiKey | quote }}
             {{- else }}
             {{- end }}
-            {{- include "dify.commonEnvs" . | nindent 12 }}
-            {{- include "dify.commonBackendEnvs" . | nindent 12 }}
-            {{- with .Values.global.extraEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.global.extraBackendEnvs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.pluginDaemon.envs }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "dify.backendEnvs" (dict "ctx" . "componentEnvs" .Values.pluginDaemon.envs) | nindent 12 }}
           volumeMounts:
             - name: plugin-daemon-storage
               mountPath: /app/storage


### PR DESCRIPTION
## Summary

The chart emits **duplicate env-var names** in some containers, relying on the container runtime's "last value wins." This happens even with default values — the `plugin-daemon` gets two `DB_DATABASE` entries (one from `global.extraBackendEnvs` plumbing / `commonBackendEnvs`, one from `pluginDaemon.envs`) — and any user who sets a var already present in a chart default (e.g. `CODE_MAX_*` via `global.extraBackendEnvs`) gets duplicates too.

Duplicate names are tolerated at **runtime**, but a container's `env` is a strategic-merge list keyed by `name` (`patchStrategy:"merge", patchMergeKey:"name"`). Any tool that computes a strategic-merge diff — `kubectl apply`, `helm upgrade` (three-way merge), **ArgoCD** — fails on duplicate keys with:

```
failed to construct strategic merge patch:
The order in patch list [...] doesn't match $setElementOrder list [...]
```

So the chart's rendered manifests are effectively **incompatible with GitOps / declarative apply**. A first-time `helm install` works (no diff), which is why it often goes unnoticed.

fix #115
fix #173

## Changes

- Add a `dify.dedupeEnv` helper (last occurrence wins, first-occurrence order preserved) in `templates/_helpers.tpl`.
- Add two thin wrappers, `dify.backendEnvs` and `dify.frontendEnvs`, that assemble each container's env in the **existing upstream order** (`commonEnvs` → `commonBackendEnvs` → `global.extraEnvs` → `global.extraBackendEnvs` → component `envs`) and then de-dupe.
- Replace the inline env concatenation in `templates/deployment.yaml` for `api`, `worker`, `worker-beat`, `plugin-daemon` (all `backendEnvs`) and `frontend` (`frontendEnvs`). Inline preambles (`- name: MODE`; the plugin-daemon's `DIFY_INNER_API_URL` / `PLUGIN_WORKING_PATH` / `SERVER_KEY` / `DIFY_INNER_API_KEY` block) stay inline — their names don't collide with the tail. The `sandbox` container has no `commonEnvs` and is untouched.
- Bump chart version `0.10.0` → `0.10.1`.

## Backward compatibility / behavior

De-dup applies the **same last-wins rule the runtime already used**, so the *effective* environment of every container is unchanged — it only removes the duplicate list entries. Verified against a before/after `helm template` (default values and a values set that intentionally duplicates `DB_DATABASE`/`CODE_MAX_STRING_LENGTH`): identical env-name set per container, each surviving var keeps its last-wins value, `valueFrom` entries intact, no var dropped. The only externally visible change is that the rendered manifests are now well-formed (no duplicate keys), so `kubectl apply` / `helm upgrade` / ArgoCD can diff them.

Requires Helm's `fromYamlArray` (Helm 3.x) — already the chart's minimum.

## Testing

```bash
# default render — plugin-daemon no longer has a duplicate DB_DATABASE
helm template dify charts/dify | \
  yq 'select(.kind=="Deployment").spec.template.spec.containers[].env[].name' | sort | uniq -d

# with a values set that duplicates chart defaults — no duplicate names emitted
helm template dify charts/dify \
  --set global.extraBackendEnvs[0].name=DB_DATABASE --set global.extraBackendEnvs[0].value=custom \
  --set global.extraBackendEnvs[1].name=CODE_MAX_STRING_LENGTH --set global.extraBackendEnvs[1].value=999

helm lint charts/dify   # passes
```

- Confirm each container's `env` has **no duplicate `name`**.
- Diff the effective (last-wins) env of each container against `master` — identical for both the default values and the duplicating values set.